### PR TITLE
Remove duplicate command "bash vessel init"

### DIFF
--- a/source/docs/updating-resetting.md
+++ b/source/docs/updating-resetting.md
@@ -42,7 +42,6 @@ Then you can re-publish the new Vessel files:
 ```bash
 # Note vessel isn't available to use here at this point
 php artisan vendor:publish --provider="Vessel\VesselServiceProvider"
-bash vessel init
 ```
 
 > **Note**: If you have customized Vessel files, you'll need to save those customizations and re-implement them into the latest Vessel files.


### PR DESCRIPTION
in the "2. Publish Latest Vessel Files" section there is the command `bash vessel init`, in the next section, "3. Re-initialize Vessel", there is also a command to run `bash vessel init` again.

this pull request is to remove `bash vessel init` in the "2. Publish Latest Vessel Files" section.